### PR TITLE
fix: added `sql-formatter` as normal dependency to `backend` package

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,11 +15,6 @@
         "README.md"
     ],
     "license": "MIT",
-    "dependencies": {
-        "@synthql/queries": "0.34.4",
-        "kysely": "^0.27.3",
-        "pg": "^8.11.3"
-    },
     "scripts": {
         "test": "vitest",
         "test:ci": "CI=1 vitest run --globals",
@@ -31,6 +26,12 @@
         "cov": "open coverage/index.html",
         "format": "yarn prettier --config ../../prettier.config.js --write ./src/"
     },
+    "dependencies": {
+        "@synthql/queries": "0.34.4",
+        "kysely": "^0.27.3",
+        "pg": "^8.11.3",
+        "sql-formatter": "^15.0.2"
+    },
     "devDependencies": {
         "@types/node": "^20.10.5",
         "@types/pg": "^8.10.9",
@@ -40,7 +41,6 @@
         "kysely-codegen": "^0.11.0",
         "postgres": "^3.4.3",
         "rollup-plugin-node-externals": "^7.1.1",
-        "sql-formatter": "^15.0.2",
         "typescript": "^5.4.5",
         "vitest": "^1.1.0"
     }


### PR DESCRIPTION
# SynthQL pull request template

## Why

To fix the issue with the CLI breaking due to this package missing from the backend

## What changed

Added a single dependency

## Important

Nothing much.