### PR TITLE
feat: infer grouping ID based on schema

### DIFF
--- a/packages/backend/src/execution/execute.test.ts
+++ b/packages/backend/src/execution/execute.test.ts
@@ -44,6 +44,10 @@ const schemaWithVirtualTables = {
                                     type: 'boolean',
                                     const: true,
                                 },
+                                isPrimaryKey: {
+                                    type: 'boolean',
+                                    const: true,
+                                },
                             },
                         },
                         rating: {
@@ -51,6 +55,10 @@ const schemaWithVirtualTables = {
                                 selectable: {
                                     type: 'boolean',
                                     const: true,
+                                },
+                                isPrimaryKey: {
+                                    type: 'boolean',
+                                    const: false,
                                 },
                             },
                         },
@@ -150,7 +158,6 @@ describe('execute', () => {
     test('single provider', async () => {
         const q = from('actor')
             .columns('actor_id', 'first_name', 'last_name')
-            .groupingId('actor_id')
             .where({ actor_id: 1 })
             .one();
 
@@ -172,7 +179,6 @@ describe('execute', () => {
         function findFilmWithRating(filmId: number) {
             return from('film')
                 .columns('film_id', 'title')
-                .groupingId('film_id')
                 .where({ film_id: filmId })
                 .include({
                     rating: from('film_rating')

--- a/packages/backend/src/execution/executors/PgExecutor/PgExecutor.test.ts
+++ b/packages/backend/src/execution/executors/PgExecutor/PgExecutor.test.ts
@@ -25,7 +25,6 @@ describe('PgExecutor', () => {
         .where({
             film_id: { '= any': [2] },
         })
-        .groupingId('film_id')
         .one();
 
     it('compiles', () => {

--- a/packages/backend/src/execution/planning/createPlanningQuery.test.ts
+++ b/packages/backend/src/execution/planning/createPlanningQuery.test.ts
@@ -128,7 +128,6 @@ describe('createPlanningQuery', () => {
     test('sore => address => city', () => {
         const city = from('city')
             .columns('city_id', 'city')
-            .groupingId('city_id')
             .where({
                 city_id: col('address.city_id'),
             })
@@ -136,7 +135,6 @@ describe('createPlanningQuery', () => {
 
         const address = from('address')
             .columns('address_id', 'address')
-            .groupingId('address_id')
             .where({
                 address_id: col('store.address_id'),
             })
@@ -147,7 +145,6 @@ describe('createPlanningQuery', () => {
 
         const query = from('store')
             .select({ store_id: true })
-            .groupingId('store_id')
             .include({
                 address,
             })

--- a/packages/backend/src/tests/e2e/nx1.test.ts
+++ b/packages/backend/src/tests/e2e/nx1.test.ts
@@ -23,7 +23,6 @@ describe('n x 1', () => {
                 .include({
                     lang,
                 })
-                .groupingId('film_id')
                 .many();
         }
 

--- a/packages/backend/src/tests/e2e/nxm.test.ts
+++ b/packages/backend/src/tests/e2e/nxm.test.ts
@@ -18,7 +18,6 @@ describe('n x m', () => {
         .where({
             film_id: col('inventory.film_id'),
         })
-        .groupingId('film_id')
         .many();
 
     const inventory = from('inventory')
@@ -27,7 +26,6 @@ describe('n x m', () => {
         .include({
             film,
         })
-        .groupingId('inventory_id')
         .many();
 
     const q = from('store')
@@ -35,7 +33,6 @@ describe('n x m', () => {
         .include({
             inventory,
         })
-        .groupingId('store_id')
         .where({ store_id: 1 })
         .one();
 

--- a/packages/backend/src/tests/e2e/select.test.ts
+++ b/packages/backend/src/tests/e2e/select.test.ts
@@ -124,7 +124,6 @@ describe('select', () => {
 
         const city = from('city')
             .select({ city_id: true, city: true })
-            .groupingId('city_id')
             .where({
                 city_id: col('address.city_id'),
             })
@@ -132,7 +131,6 @@ describe('select', () => {
 
         const address = from('address')
             .select({ address_id: true, address: true, city: true })
-            .groupingId('address_id')
             .where({
                 address_id: col('store.address_id'),
             })
@@ -143,7 +141,6 @@ describe('select', () => {
 
         const query = from('store')
             .select({ store_id: true })
-            .groupingId('store_id')
             .include({
                 address,
             })

--- a/packages/backend/src/tests/e2e/store-with-customers.test.ts
+++ b/packages/backend/src/tests/e2e/store-with-customers.test.ts
@@ -21,7 +21,6 @@ describe.skip('e2e', () => {
         .many();
 
     const customers = from('customer')
-        .groupingId('customer_id')
         .columns('email', 'customer_id')
         .where({ store_id: col('store.store_id'), customer_id: 367 })
         .include({
@@ -35,7 +34,6 @@ describe.skip('e2e', () => {
             customers,
         })
         .where({ store_id: { in: [1] } })
-        .groupingId('store_id')
         .one();
 
     const pgExecutor = new PgExecutor({

--- a/packages/backend/src/tests/queries.ts
+++ b/packages/backend/src/tests/queries.ts
@@ -6,14 +6,12 @@ export function from<TTable extends Table<DB>>(table: TTable) {
 }
 
 export function actor() {
-    return from('actor')
-        .select({
-            actor_id: true,
-            first_name: true,
-            last_name: true,
-            last_update: true,
-        })
-        .groupingId('actor_id');
+    return from('actor').select({
+        actor_id: true,
+        first_name: true,
+        last_name: true,
+        last_update: true,
+    });
 }
 
 export function findActorById(actorId: number) {
@@ -25,13 +23,11 @@ export function findActors() {
 }
 
 export function language() {
-    return from('language')
-        .select({
-            language_id: true,
-            name: true,
-            last_update: true,
-        })
-        .groupingId('language_id');
+    return from('language').select({
+        language_id: true,
+        name: true,
+        last_update: true,
+    });
 }
 
 export function findLanguageById(
@@ -58,18 +54,15 @@ export function movie() {
                     actor_id: col('film_actor.actor_id'),
                 })
                 .many(),
-        })
-        .groupingId('film_id');
+        });
 }
 
 export function country() {
-    return from('country')
-        .select({
-            country_id: true,
-            country: true,
-            last_update: true,
-        })
-        .groupingId('country_id');
+    return from('country').select({
+        country_id: true,
+        country: true,
+        last_update: true,
+    });
 }
 
 function findCountryById(id: WhereClause<DB, 'country', 'country_id'>) {
@@ -84,7 +77,6 @@ export function city() {
             last_update: true,
             country_id: true,
         })
-        .groupingId('city_id')
         .include({
             country: findCountryById(col('city.country_id')).one(),
         });

--- a/packages/backend/src/tests/queries.v2.ts
+++ b/packages/backend/src/tests/queries.v2.ts
@@ -2,15 +2,11 @@ import { col } from '@synthql/queries';
 import { from } from './generated';
 
 export function language() {
-    return from('language')
-        .groupingId('language_id')
-        .columns('name', 'language_id');
+    return from('language').columns('name', 'language_id');
 }
 
 export function actor() {
-    return from('actor')
-        .groupingId('actor_id')
-        .columns('first_name', 'last_name', 'actor_id');
+    return from('actor').columns('first_name', 'last_name', 'actor_id');
 }
 
 export function filmActor() {
@@ -20,7 +16,6 @@ export function filmActor() {
 export function film() {
     return from('film')
         .columns('title', 'release_year')
-        .groupingId('film_id')
         .include({
             language: language()
                 .where({ language_id: col('film.language_id') })
@@ -37,13 +32,12 @@ export function film() {
 }
 
 export function city() {
-    return from('city').columns('city_id', 'city').groupingId('city_id');
+    return from('city').columns('city_id', 'city');
 }
 
 export function address() {
     return from('address')
         .columns('address_id', 'address')
-        .groupingId('address_id')
         .include({
             city: city()
                 .where({ city_id: col('address.city_id') })
@@ -54,7 +48,6 @@ export function address() {
 export function inventory() {
     return from('inventory')
         .columns('inventory_id')
-        .groupingId('inventory_id')
         .include({
             film: film()
                 .where({ film_id: col('inventory.film_id') })
@@ -75,7 +68,6 @@ export function inventory() {
 export function store() {
     return from('store')
         .columns('store_id', 'address_id')
-        .groupingId('store_id')
         .include({
             address: address()
                 .where({ address_id: col('store.address_id') })

--- a/packages/backend/src/util/handlers/createExpressSynthqlHandler.test.ts
+++ b/packages/backend/src/util/handlers/createExpressSynthqlHandler.test.ts
@@ -6,7 +6,6 @@ describe('createExpressSynthqlHandler', () => {
     test(`Query execution is successful`, async () => {
         const q = from('actor')
             .columns('actor_id', 'first_name', 'last_name')
-            .groupingId('actor_id')
             .where({ actor_id: { in: [1] } })
             .one();
     });
@@ -14,7 +13,6 @@ describe('createExpressSynthqlHandler', () => {
     test(`Query execution is successful with returnLastOnly passed`, async () => {
         const q = from('actor')
             .columns('actor_id', 'first_name', 'last_name')
-            .groupingId('actor_id')
             .where({ actor_id: { in: [1] } })
             .maybe();
     });

--- a/packages/queries/src/query.ts
+++ b/packages/queries/src/query.ts
@@ -5,6 +5,7 @@ import { Column } from './types/Column';
 import { Table } from './types/Table';
 import { DbSchema } from './types/DbSchema';
 import { getSelectableColumns } from './schema/getSelectableColumns';
+import { getPrimaryKey } from './schema/getPrimaryKey';
 
 export class QueryBuilder<
     DB,
@@ -332,7 +333,11 @@ export function query<DB>(schema: DbSchema<DB>) {
         from<TTable extends Table<DB>>(table: TTable) {
             type TKeys = Array<Column<DB, TTable>>;
 
+            type TPrimaryKey = Array<string>;
+
             const select = getSelectableColumns<DB>(schema, table);
+
+            const primaryKey = getPrimaryKey<DB>(schema, table);
 
             return new QueryBuilder<
                 DB,
@@ -342,8 +347,10 @@ export function query<DB>(schema: DbSchema<DB>) {
                 {},
                 'many',
                 undefined,
-                ['id']
-            >(table, {}, select, {}, undefined, 'many', undefined, ['id']);
+                TPrimaryKey
+            >(table, {}, select, {}, undefined, 'many', undefined, [
+                primaryKey,
+            ]);
         },
     };
 }

--- a/packages/queries/src/query.ts
+++ b/packages/queries/src/query.ts
@@ -333,11 +333,9 @@ export function query<DB>(schema: DbSchema<DB>) {
         from<TTable extends Table<DB>>(table: TTable) {
             type TKeys = Array<Column<DB, TTable>>;
 
-            type TPrimaryKey = Array<string>;
-
             const select = getSelectableColumns<DB>(schema, table);
 
-            const primaryKey = getPrimaryKey<DB>(schema, table);
+            const primaryKeys = getPrimaryKey<DB>(schema, table);
 
             return new QueryBuilder<
                 DB,
@@ -347,10 +345,8 @@ export function query<DB>(schema: DbSchema<DB>) {
                 {},
                 'many',
                 undefined,
-                TPrimaryKey
-            >(table, {}, select, {}, undefined, 'many', undefined, [
-                primaryKey,
-            ]);
+                typeof primaryKeys
+            >(table, {}, select, {}, undefined, 'many', undefined, primaryKeys);
         },
     };
 }

--- a/packages/queries/src/schema/getPrimaryKey.test.ts
+++ b/packages/queries/src/schema/getPrimaryKey.test.ts
@@ -6,6 +6,6 @@ describe('getPrimaryKey', () => {
     test('Get the primary key for a table', () => {
         const primaryKey = getPrimaryKey<DB>(schema, 'actor');
 
-        expect(primaryKey).toEqual('actor_id');
+        expect(primaryKey).toEqual(['actor_id']);
     });
 });

--- a/packages/queries/src/schema/getPrimaryKey.test.ts
+++ b/packages/queries/src/schema/getPrimaryKey.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest';
+import { DB, schema } from '../generated';
+import { getPrimaryKey } from './getPrimaryKey';
+
+describe('getPrimaryKey', () => {
+    test('Get the primary key for a table', () => {
+        const primaryKey = getPrimaryKey<DB>(schema, 'actor');
+
+        expect(primaryKey).toEqual('actor_id');
+    });
+});

--- a/packages/queries/src/schema/getPrimaryKey.ts
+++ b/packages/queries/src/schema/getPrimaryKey.ts
@@ -20,14 +20,16 @@ import { getColumnDefs, getTableDef, isPrimaryKeyColumn } from './getTableDefs';
 export function getPrimaryKey<DB>(
     schema: DbSchema<DB>,
     table: Table<DB>,
-): string {
+): Array<string> {
+    const primaryKeys: Array<string> = [];
+
     const tableDef = getTableDef<DB>(schema, table);
 
     for (const [columnName, columnDef] of getColumnDefs<DB>(tableDef)) {
         if (isPrimaryKeyColumn(columnDef)) {
-            return columnName;
+            primaryKeys.push(columnName);
         }
     }
 
-    return 'id';
+    return primaryKeys;
 }

--- a/packages/queries/src/schema/getPrimaryKey.ts
+++ b/packages/queries/src/schema/getPrimaryKey.ts
@@ -1,0 +1,33 @@
+import { DbSchema } from '../types/DbSchema';
+import { Table } from '../types/Table';
+import { getColumnDefs, getTableDef, isPrimaryKeyColumn } from './getTableDefs';
+
+/**
+ * Get the primary key of a table, as defined in the database schema.
+ *
+ * Example:
+ *
+ * ```ts
+ * const primaryKey = getPrimaryKey<DB>(schema, 'actor');
+ *
+ * console.log(primaryKey); // Prints 'actor_id'
+ * ```
+ *
+ * @param schema The generated schema object for the database
+ * @param table The name of the table
+ */
+
+export function getPrimaryKey<DB>(
+    schema: DbSchema<DB>,
+    table: Table<DB>,
+): string {
+    const tableDef = getTableDef<DB>(schema, table);
+
+    for (const [columnName, columnDef] of getColumnDefs<DB>(tableDef)) {
+        if (isPrimaryKeyColumn(columnDef)) {
+            return columnName;
+        }
+    }
+
+    return 'id';
+}

--- a/packages/queries/src/schema/getSelectableColumns.ts
+++ b/packages/queries/src/schema/getSelectableColumns.ts
@@ -1,5 +1,6 @@
-import { ColumnSchema, DbSchema, TableSchema } from '../types/DbSchema';
+import { DbSchema } from '../types/DbSchema';
 import { Table } from '../types/Table';
+import { getColumnDefs, getTableDef, isSelectableColumn } from './getTableDefs';
 
 type SelectableColumnsType = Record<string, true>;
 
@@ -9,7 +10,7 @@ type SelectableColumnsType = Record<string, true>;
  * Example:
  *
  * ```ts
- * const select = getSelectableColumns(schema, 'actor');
+ * const select = getSelectableColumns<DB>(schema, 'actor');
  *
  * select =
  *   actor_id: true,
@@ -20,7 +21,7 @@ type SelectableColumnsType = Record<string, true>;
  * ```
  *
  * @param schema The generated schema object for the database
- * @param table The name of the table.
+ * @param table The name of the table
  */
 
 export function getSelectableColumns<DB>(
@@ -38,21 +39,4 @@ export function getSelectableColumns<DB>(
     }
 
     return select;
-}
-
-function getTableDef<DB>(
-    schema: DbSchema<DB>,
-    table: Table<DB>,
-): TableSchema<DB> {
-    return schema.properties[table];
-}
-
-function getColumnDefs<DB>(
-    tableDef: TableSchema<DB>,
-): [string, ColumnSchema][] {
-    return Object.entries(tableDef.properties.columns.properties);
-}
-
-function isSelectableColumn(columnDef: ColumnSchema): boolean {
-    return columnDef.properties.selectable.const;
 }

--- a/packages/queries/src/schema/getTableDefs.ts
+++ b/packages/queries/src/schema/getTableDefs.ts
@@ -1,0 +1,31 @@
+import { Column } from '../types/Column';
+import { ColumnSchema, DbSchema, TableSchema } from '../types/DbSchema';
+import { Table } from '../types/Table';
+
+export function getTableDef<DB>(
+    schema: DbSchema<DB>,
+    table: Table<DB>,
+): TableSchema<DB> {
+    return schema.properties[table];
+}
+
+export function getColumnDefs<DB>(
+    tableDef: TableSchema<DB>,
+): [string, ColumnSchema][] {
+    return Object.entries(tableDef.properties.columns.properties);
+}
+
+export function isSelectableColumn(columnDef: ColumnSchema): boolean {
+    return columnDef.properties.selectable.const;
+}
+
+export function isPrimaryKeyColumn(columnDef: ColumnSchema): boolean {
+    return columnDef.properties.isPrimaryKey.const;
+}
+
+export function isValidColumnName<DB, TTable extends Table<DB>>(
+    key: string,
+): key is Column<DB, TTable> {
+    // return conditional logic should go here, but for now we default false
+    return false;
+}

--- a/packages/queries/src/schema/getTableDefs.ts
+++ b/packages/queries/src/schema/getTableDefs.ts
@@ -1,4 +1,3 @@
-import { Column } from '../types/Column';
 import { ColumnSchema, DbSchema, TableSchema } from '../types/DbSchema';
 import { Table } from '../types/Table';
 
@@ -21,11 +20,4 @@ export function isSelectableColumn(columnDef: ColumnSchema): boolean {
 
 export function isPrimaryKeyColumn(columnDef: ColumnSchema): boolean {
     return columnDef.properties.isPrimaryKey.const;
-}
-
-export function isValidColumnName<DB, TTable extends Table<DB>>(
-    key: string,
-): key is Column<DB, TTable> {
-    // return conditional logic should go here, but for now we default false
-    return false;
 }

--- a/packages/queries/src/types/DbSchema.ts
+++ b/packages/queries/src/types/DbSchema.ts
@@ -21,5 +21,9 @@ export interface ColumnSchema {
             type: string;
             const: boolean;
         };
+        isPrimaryKey: {
+            type: string;
+            const: boolean;
+        };
     };
 }

--- a/packages/react/src/test/echoDb.ts
+++ b/packages/react/src/test/echoDb.ts
@@ -17,6 +17,10 @@ const schema = {
                                     type: 'boolean',
                                     const: true,
                                 },
+                                isPrimaryKey: {
+                                    type: 'boolean',
+                                    const: true,
+                                },
                             },
                         },
                         name: {
@@ -24,6 +28,10 @@ const schema = {
                                 selectable: {
                                     type: 'boolean',
                                     const: true,
+                                },
+                                isPrimaryKey: {
+                                    type: 'boolean',
+                                    const: false,
                                 },
                             },
                         },

--- a/packages/react/src/useSynthql.test.tsx
+++ b/packages/react/src/useSynthql.test.tsx
@@ -61,7 +61,6 @@ describe('useSynthql', () => {
         // @@desc@@ Finds 0 or 1 record(s) in the `actors` table where the `id` is in the list of ids and return all selectable columns.
 
         const q = from('actor')
-            .groupingId('actor_id')
             .where({ actor_id: { in: [1] } })
             .one();
 
@@ -88,7 +87,6 @@ describe('useSynthql', () => {
 
         const q = from('actor')
             .columns('actor_id', 'first_name', 'last_name')
-            .groupingId('actor_id')
             .where({ actor_id: { in: [1] } })
             .maybe();
 
@@ -119,7 +117,6 @@ describe('useSynthql', () => {
 
         const q = from('actor')
             .columns('actor_id', 'first_name', 'last_name')
-            .groupingId('actor_id')
             .where({ actor_id: { in: ids } })
             .many();
 
@@ -196,7 +193,6 @@ describe('useSynthql', () => {
 
         const store = from('store')
             .columns('store_id', 'address_id', 'manager_staff_id')
-            .groupingId('store_id')
             .where({
                 store_id: col('customer.store_id'),
             })
@@ -210,7 +206,6 @@ describe('useSynthql', () => {
                 'last_name',
                 'email',
             )
-            .groupingId('customer_id')
             .where({ customer_id: { in: [1] } })
             .include({ store })
             .one();
@@ -244,7 +239,6 @@ describe('useSynthql', () => {
 
         const address = from('address')
             .columns('address_id', 'address', 'district')
-            .groupingId('address_id')
             .where({
                 address_id: col('store.address_id'),
             })
@@ -252,7 +246,6 @@ describe('useSynthql', () => {
 
         const store = from('store')
             .columns('store_id', 'address_id', 'manager_staff_id')
-            .groupingId('store_id')
             .where({
                 store_id: col('customer.store_id'),
             })
@@ -267,7 +260,6 @@ describe('useSynthql', () => {
                 'last_name',
                 'email',
             )
-            .groupingId('customer_id')
             .where({ customer_id: { in: [4] } })
             .include({ store })
             .one();
@@ -307,7 +299,6 @@ describe('useSynthql', () => {
 
         const city = from('city')
             .columns('city_id', 'city')
-            .groupingId('city_id')
             .where({
                 city_id: col('address.city_id'),
             })
@@ -315,7 +306,6 @@ describe('useSynthql', () => {
 
         const address = from('address')
             .columns('address_id', 'city_id', 'address', 'district')
-            .groupingId('address_id')
             .where({
                 address_id: col('store.address_id'),
             })
@@ -324,7 +314,6 @@ describe('useSynthql', () => {
 
         const store = from('store')
             .columns('store_id', 'address_id', 'manager_staff_id')
-            .groupingId('store_id')
             .where({
                 store_id: col('customer.store_id'),
             })
@@ -339,7 +328,6 @@ describe('useSynthql', () => {
                 'last_name',
                 'email',
             )
-            .groupingId('customer_id')
             .where({ customer_id: { in: [4] } })
             .include({ store })
             .one();


### PR DESCRIPTION
# SynthQL pull request template

## Why

We want to infer the grouping ID for a table when a user is using the query API

## What changed

A new function that extracts the column and passes it to the QueryBuilder, plus some updates to the tests that reflect this change

## Important